### PR TITLE
fix(techdocs): prevent to throw error on undefined 'selection'

### DIFF
--- a/.changeset/unlucky-carrots-shave.md
+++ b/.changeset/unlucky-carrots-shave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-module-addons-contrib': patch
+---
+
+prevent to throw an error when the SCM provider is not supported

--- a/plugins/techdocs-module-addons-contrib/src/ReportIssue/ReportIssue.tsx
+++ b/plugins/techdocs-module-addons-contrib/src/ReportIssue/ReportIssue.tsx
@@ -102,7 +102,7 @@ export const ReportIssueAddon = ({
       // todo(backstage/techdocs-core) handle non-repo rendering
       !repository ||
       !selection ||
-      !selection.containsNode(mainContent!, true) ||
+      !selection?.containsNode(mainContent!, true) ||
       selection?.containsNode(feedbackContainer!, true)
     ) {
       return;


### PR DESCRIPTION
Error
TypeError

Message
Failed to execute 'containsNode' on 'Selection': parameter 1 is not of type 'Node'.

Stack Trace
TypeError: parameter 1 is not of type 'Node'.
    at https://backstage.mpi-internal.com/static/module-backstage.b2517ed5.js:618:1729
    at ul (https://backstage.mpi-internal.com/static/module-react-dom.b4fe5cf3.js:16:24313)
    at Ct (https://backstage.mpi-internal.com/static/module-react-dom.b4fe5cf3.js:16:42455)
    at qs (https://backstage.mpi-internal.com/static/module-react-dom.b4fe5cf3.js:16:34578)
    at Ln (https://backstage.mpi-internal.com/static/module-react-dom.b4fe5cf3.js:24:1590)
    at MessagePort.Zn (https://backstage.mpi-internal.com/static/module-react-dom.b4fe5cf3.js:24:1980)

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
